### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,13 @@
     "name": "Phi-3 Cookbook",
     "image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
     "features": {
-        "ghcr.io/prulloac/devcontainer-features/ollama:1": {}
+        "ghcr.io/prulloac/devcontainer-features/ollama:1": {
+            "pull": "phi3"
+        }
+    },
+    // Set minimal host requirements for the container.
+    "hostRequirements": {
+        "memory": "16gb"
     },
     // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"


### PR DESCRIPTION
## Purpose

- Automatically pull phi3
- Set minimum requirements to allow latest ollama to run with Phi3

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


