### PR TITLE
Fix: corrected command for mlx generate with quantized phi-3

### DIFF
--- a/md/03.Inference/MLX_Inference.md
+++ b/md/03.Inference/MLX_Inference.md
@@ -53,7 +53,7 @@ We can test the model quantized with MLX from terminal
 
 ```bash
 
-python -m mlx_lm.convert --hf-path microsoft/Phi-3-mini-4k-instruct
+python -m mlx_lm.generate --model ./mlx_model/ --max-token 2048 --prompt  "<|user|>\nCan you introduce yourself<|end|>\n<|assistant|>"
 
 ```
 


### PR DESCRIPTION
## Purpose

The command given in the docs for mlx generation of a quantized phi model is incorrectly given as the duplication of the command used to quantize the model:
```
python -m mlx_lm.convert --hf-path microsoft/Phi-3-mini-4k-instruct
```` 

This PR corrects the command to:
```
python -m mlx_lm.generate --model ./mlx_model/ --max-token 2048 --prompt "<|user|>\nCan you introduce yourself<|end|>\n<|assistant|>"
```

The corrected command provides an output which is the same as the existing terminal display image shown in the following line of the docs.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


