### PR TITLE
missing "," in doc added

### DIFF
--- a/md/02.QuickStart/Ollama_QuickStart.md
+++ b/md/02.QuickStart/Ollama_QuickStart.md
@@ -123,7 +123,7 @@ client = openai.OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="phi3"
+    model="phi3",
     temperature=0.7,
     n=1,
     messages=[


### PR DESCRIPTION
There was small missing "," in the documentations. 