### PR TITLE
Add link to Guidance breakout session recording at Build

### DIFF
--- a/code/01.Introduce/guidance.ipynb
+++ b/code/01.Introduce/guidance.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "Guidance differs from conventional prompting techniques.  It enforces constraints by steering the model token by token in the inference layer, producing higher quality outputs and reducing cost and latency by as much as 30–50% when utilizing for highly structured scenarios.\n",
     "\n",
-    "To learn more about Guidance, visit the [public repository on GitHub](https://github.com/guidance-ai/guidance) or watch the Guidance Breakout Session at Microsoft Build."
+    "To learn more about Guidance, visit the [public repository on GitHub](https://github.com/guidance-ai/guidance) or watch the [Guidance Breakout Session](https://www.youtube.com/watch?v=qXMNPVVlCMs) at Microsoft Build."
    ]
   },
   {


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Adds a link to the YouTube video recording of the Guidance breakout session at MS Build 2024.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```


