### PR TITLE
Update FineTuning_MLX.md

### DIFF
--- a/md/04.Fine-tuning/FineTuning_MLX.md
+++ b/md/04.Fine-tuning/FineTuning_MLX.md
@@ -110,7 +110,7 @@ lora_parameters:
   # These will be applied for the last lora_layers
   keys: ["o_proj","qkv_proj"]
   rank: 64
-  alpha: 64
+  scale: 1
   dropout: 0.1
 
 


### PR DESCRIPTION


## Purpose

alpha is not supported anymore in recent versions of MLX and it has been replaced by scale. 
Without this change, fine-tuning fails with: KeyError: 'scale' message

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[ X] No
```

## Type of change

```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


