### PR TITLE
use https instead of http for vscode urls

### DIFF
--- a/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@
 
 ## For more information
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 语法参考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@
 
 ## For more information
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 语法参考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@ You can author your README using Visual Studio Code. Here are some useful editor
 
 ## For more information
 
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+* [Visual Studio Code's Markdown Support](https://code.visualstudio.com/docs/languages/markdown)
 * [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
 
 **Enjoy!**

--- a/translations/es/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/translations/es/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@ Puedes usar Visual Studio Code para redactar tu README. Aquí tienes algunos ata
 
 ## For more information
 
-* [Soporte de Markdown en Visual Studio Code](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Soporte de Markdown en Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Referencia de sintaxis Markdown](https://help.github.com/articles/markdown-basics/)
 
 **¡Disfruta!**

--- a/translations/es/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/translations/es/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@ Puedes usar Visual Studio Code para escribir tu README. Aquí tienes algunos ata
 
 ## For more information
 
-* [Soporte de Markdown en Visual Studio Code](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Soporte de Markdown en Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Referencia de sintaxis de Markdown](https://help.github.com/articles/markdown-basics/)
 
 **¡Disfruta!**

--- a/translations/es/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/translations/es/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@ Puedes redactar tu README utilizando Visual Studio Code. Aquí tienes algunos at
 
 ## Para más información
 
-* [Soporte de Markdown en Visual Studio Code](http://code.visualstudio.com/docs/languages/markdown)
+* [Soporte de Markdown en Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown)
 * [Referencia de Sintaxis de Markdown](https://help.github.com/articles/markdown-basics/)
 
 **¡Disfruta!**

--- a/translations/fr/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/translations/fr/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@ Vous pouvez utiliser Visual Studio Code pour rédiger votre README. Voici quelqu
 
 ## Pour plus d'informations
 
-* [Support Markdown de Visual Studio Code](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Support Markdown de Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Référence de syntaxe Markdown](https://help.github.com/articles/markdown-basics/)
 
 **Profitez-en !**

--- a/translations/fr/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/translations/fr/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@ Vous pouvez utiliser Visual Studio Code pour rédiger votre README. Voici quelqu
 
 ## Pour plus d'informations
 
-* [Support Markdown de Visual Studio Code](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Support Markdown de Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Référence de la syntaxe Markdown](https://help.github.com/articles/markdown-basics/)
 
 **Profitez-en !**

--- a/translations/fr/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/translations/fr/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@ Vous pouvez rédiger votre README en utilisant Visual Studio Code. Voici quelque
 
 ## Pour plus d'informations
 
-* [Support Markdown de Visual Studio Code](http://code.visualstudio.com/docs/languages/markdown)
+* [Support Markdown de Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown)
 * [Référence de la syntaxe Markdown](https://help.github.com/articles/markdown-basics/)
 
 **Amusez-vous bien !**

--- a/translations/ja/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/translations/ja/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@ Visual Studio Code を使用して README を作成することができます�
 
 ## For more information
 
-* [Visual Studio Code の Markdown サポート](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code の Markdown サポート](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown の基本](https://help.github.com/articles/markdown-basics/)
 
 **楽しんでください！**

--- a/translations/ja/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/translations/ja/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@ Visual Studio Code を使用して README を作成できます。以下に便�
 
 ## For more information
 
-* [Visual Studio Code の Markdown サポート](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code の Markdown サポート](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown の基本](https://help.github.com/articles/markdown-basics/)
 
 **楽しんでください！**

--- a/translations/ja/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/translations/ja/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@ Visual Studio Codeを使用してREADMEを作成できます。以下は便利�
 
 ## 詳細情報
 
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+* [Visual Studio Code's Markdown Support](https://code.visualstudio.com/docs/languages/markdown)
 * [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
 
 **お楽しみください！**

--- a/translations/ko/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/translations/ko/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@ Visual Studio Code를 사용하여 README를 작성할 수 있습니다. 다음�
 
 ## For more information
 
-* [Visual Studio Code의 Markdown 지원](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code의 Markdown 지원](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 문법 참조](https://help.github.com/articles/markdown-basics/)
 
 **즐기세요!**

--- a/translations/ko/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/translations/ko/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@ Visual Studio Code를 사용하여 README를 작성할 수 있습니다. 다음�
 
 ## For more information
 
-* [Visual Studio Code의 Markdown 지원](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code의 Markdown 지원](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 문법 참조](https://help.github.com/articles/markdown-basics/)
 
 **즐기세요!**

--- a/translations/ko/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/translations/ko/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@ Visual Studio Code를 사용하여 README를 작성할 수 있습니다. 유용�
 
 ## 추가 정보
 
-* [Visual Studio Code의 Markdown 지원](http://code.visualstudio.com/docs/languages/markdown)
+* [Visual Studio Code의 Markdown 지원](https://code.visualstudio.com/docs/languages/markdown)
 * [Markdown 구문 참조](https://help.github.com/articles/markdown-basics/)
 
 **즐기세요!**

--- a/translations/tw/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/translations/tw/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@
 
 ## For more information
 
-* [Visual Studio Code 的 Markdown 支援](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code 的 Markdown 支援](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 語法參考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/translations/tw/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/translations/tw/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@
 
 ## For more information
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 語法參考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/translations/tw/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/translations/tw/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@
 
 ## 更多信息
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown)
 * [Markdown 語法參考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/translations/zh/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
+++ b/translations/zh/code/07.Lab/01/AIPC/extensions/phi3ext/README.md
@@ -65,7 +65,7 @@
 
 ## For more information
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 语法参考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/translations/zh/code/07.Lab/01/Apple/phi3ext/README.md
+++ b/translations/zh/code/07.Lab/01/Apple/phi3ext/README.md
@@ -65,7 +65,7 @@
 
 ## 更多信息
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown?WT.mc_id=aiml-137032-kinfeylo)
 * [Markdown 语法参考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**

--- a/translations/zh/code/09.UpdateSamples/Aug/vscode/phiext/README.md
+++ b/translations/zh/code/09.UpdateSamples/Aug/vscode/phiext/README.md
@@ -65,7 +65,7 @@
 
 ## 获取更多信息
 
-* [Visual Studio Code 的 Markdown 支持](http://code.visualstudio.com/docs/languages/markdown)
+* [Visual Studio Code 的 Markdown 支持](https://code.visualstudio.com/docs/languages/markdown)
 * [Markdown 语法参考](https://help.github.com/articles/markdown-basics/)
 
 **享受吧！**


### PR DESCRIPTION
## Purpose

The markdown-checker action doesn't handle http to https redirection which may flag these urls as broken since vscode enforces https.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


