### PR TITLE
Update the CsharpOllamaCodeSpaces c# samples to use phi3.5 and fix RAG errors

### DIFF
--- a/.devcontainer/csollamaphi3.5/devcontainer.json
+++ b/.devcontainer/csollamaphi3.5/devcontainer.json
@@ -1,49 +1,49 @@
 {
-    "name": "Ollama with Phi-3.5 for C#",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
-    "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers/features/common-utils:2": {},
-        "ghcr.io/devcontainers/features/dotnet:2": {
-            "version": "none",
-            "dotnetRuntimeVersions": "8.0",
-            "aspNetCoreRuntimeVersions": "8.0"
-        },
-        "ghcr.io/prulloac/devcontainer-features/ollama:1": {
-            "pull": "phi3"
-        },
-        "sshd": "latest"
+  "name": "Ollama with Phi-3.5 for C#",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "none",
+      "dotnetRuntimeVersions": "8.0",
+      "aspNetCoreRuntimeVersions": "8.0"
     },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-vscode.vscode-node-azure-pack",
-                "github.vscode-github-actions",
-                "ms-dotnettools.csdevkit",
-				"ms-dotnettools.vscode-dotnet-runtime",
-                "github.copilot",
-                "ms-azuretools.vscode-docker"
-            ]
-        }
+    "ghcr.io/prulloac/devcontainer-features/ollama:1": {
+      "pull": "phi3"
     },
-    "forwardPorts": [
-        32000,
-        32001
-    ],
-    "postCreateCommand": "sudo dotnet workload update",
-    "postStartCommand": "ollama pull phi3.5",
-    "remoteUser": "vscode",
-    "hostRequirements": {
-        "memory": "8gb",
-        "cpus": 4
-    },
-    "portsAttributes": {
-        "32001": {
-            "label": "Back End"
-        },
-        "32000": {
-            "label": "Front End"
-        }
+    "sshd": "latest"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.vscode-node-azure-pack",
+        "github.vscode-github-actions",
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "github.copilot",
+        "ms-azuretools.vscode-docker"
+      ]
     }
+  },
+  "forwardPorts": [
+    32000,
+    32001
+  ],
+  "postCreateCommand": "sudo dotnet workload update",
+  "postStartCommand": "ollama pull phi3.5 & ollama pull all-minilm",
+  "remoteUser": "vscode",
+  "hostRequirements": {
+    "memory": "8gb",
+    "cpus": 4
+  },
+  "portsAttributes": {
+    "32001": {
+      "label": "Back End"
+    },
+    "32000": {
+      "label": "Front End"
+    }
+  }
 }

--- a/.devcontainer/csollamaphi3.5/devcontainer.json
+++ b/.devcontainer/csollamaphi3.5/devcontainer.json
@@ -5,13 +5,8 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/common-utils:2": {},
-    "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "none",
-      "dotnetRuntimeVersions": "8.0",
-      "aspNetCoreRuntimeVersions": "8.0"
-    },
     "ghcr.io/prulloac/devcontainer-features/ollama:1": {
-      "pull": "phi3"
+      "pull": "phi3.5"
     },
     "sshd": "latest"
   },
@@ -32,7 +27,7 @@
     32001
   ],
   "postCreateCommand": "sudo dotnet workload update",
-  "postStartCommand": "ollama pull phi3.5 & ollama pull all-minilm",
+  "postStartCommand": "ollama pull all-minilm",
   "remoteUser": "vscode",
   "hostRequirements": {
     "memory": "8gb",

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample01/Program.cs
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample01/Program.cs
@@ -21,20 +21,19 @@
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //    THE SOFTWARE.
 
-#pragma warning disable SKEXP0001, SKEXP0003, SKEXP0010, SKEXP0011, SKEXP0050, SKEXP0052
+#pragma warning disable SKEXP0001, SKEXP0003, SKEXP0010, SKEXP0011, SKEXP0050, SKEXP0052, SKEXP0070
+
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 
-// Create kernel with a custom http address
-var builder = Kernel.CreateBuilder();
-builder.AddOpenAIChatCompletion(
-    modelId: "phi3.5",
-    endpoint: new Uri("http://localhost:11434"),
-    apiKey: "apikey");
-var kernel = builder.Build();
+var ollamaEndpoint = "http://localhost:11434";
+var modelIdChat = "phi3.5";
 
-// 14 - define prompt execution settings
+// Create kernel with a custom http address
+var kernel = Kernel.CreateBuilder()
+    .AddOllamaChatCompletion(modelId: modelIdChat, endpoint: new Uri(ollamaEndpoint))
+    .Build();
+
 var settings = new OpenAIPromptExecutionSettings
 {
     MaxTokens = 100,

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample01/Sample01.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample01/Sample01.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+	</ItemGroup>
 
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample01/Sample01.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample01/Sample01.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+  </ItemGroup>
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample02/Sample02.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample02/Sample02.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
 	</ItemGroup>
 
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample02/Sample02.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample02/Sample02.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>506e8050-acbd-476d-ab7d-bbebc8238bfa</UserSecretsId>
   </PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
-	</ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+  </ItemGroup>
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Program.cs
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Program.cs
@@ -37,7 +37,7 @@ var modelIdEmbeddings = "all-minilm";
 var question = "What is Bruno's favourite super hero?";
 
 Console.WriteLine($"This program will answer the following question: {question}");
-Console.WriteLine("1st approach will be to ask the question directly to the Phi-3 model.");
+Console.WriteLine($"1st approach will be to ask the question directly to the {modelIdChat} model.");
 Console.WriteLine("2nd approach will be to add facts to a semantic memory and ask the question again");
 Console.WriteLine("");
 
@@ -55,7 +55,7 @@ await foreach (var result in response)
 Console.WriteLine("");
 Console.WriteLine("==============");
 Console.WriteLine("");
-Console.WriteLine($"Phi-3 response (using semantic memory).");
+Console.WriteLine($"{modelIdChat} response (using semantic memory).");
 
 var configOllamaKernelMemory = new OllamaConfig
 {

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Program.cs
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Program.cs
@@ -23,87 +23,60 @@
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //    THE SOFTWARE.
 
-#pragma warning disable SKEXP0001
-#pragma warning disable SKEXP0003
-#pragma warning disable SKEXP0010
-#pragma warning disable SKEXP0011
-#pragma warning disable SKEXP0050
-#pragma warning disable SKEXP0052
+#pragma warning disable SKEXP0001, SKEXP0003, SKEXP0010, SKEXP0011, SKEXP0050, SKEXP0052, SKEXP0070
 
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.AI.Ollama;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Connectors.OpenAI;
-using Microsoft.SemanticKernel.Embeddings;
-using Microsoft.SemanticKernel.Memory;
-using Microsoft.SemanticKernel.Plugins.Memory;
 
+var ollamaEndpoint = "http://localhost:11434";
+var modelIdChat = "phi3.5";
+var modelIdEmbeddings = "all-minilm";
+
+// questions
 var question = "What is Bruno's favourite super hero?";
+
 Console.WriteLine($"This program will answer the following question: {question}");
 Console.WriteLine("1st approach will be to ask the question directly to the Phi-3 model.");
 Console.WriteLine("2nd approach will be to add facts to a semantic memory and ask the question again");
 Console.WriteLine("");
 
 // Create a chat completion service
-var builder = Kernel.CreateBuilder();
-builder.AddOpenAIChatCompletion(
-    modelId: "phi3.5",
-    endpoint: new Uri("http://localhost:11434"),
-    apiKey: "apikey");
-builder.AddLocalTextEmbeddingGeneration();
-Kernel kernel = builder.Build();
-
-Console.WriteLine($"Phi-3 response (no memory).");
+Kernel kernel = Kernel.CreateBuilder()
+    .AddOllamaChatCompletion(modelId: modelIdChat, endpoint: new Uri(ollamaEndpoint))
+    .Build();
 var response = kernel.InvokePromptStreamingAsync(question);
 await foreach (var result in response)
 {
-    Console.Write(result);
+    Console.Write(result.ToString());
 }
 
 // separator
 Console.WriteLine("");
 Console.WriteLine("==============");
 Console.WriteLine("");
-
-// get the embeddings generator service
-var embeddingGenerator = kernel.Services.GetRequiredService<ITextEmbeddingGenerationService>();
-var memory = new SemanticTextMemory(new VolatileMemoryStore(), embeddingGenerator);
-
-// add facts to the collection
-const string MemoryCollectionName = "fanFacts";
-
-await memory.SaveInformationAsync(MemoryCollectionName, id: "info1", text: "Gisela's favourite super hero is Batman");
-await memory.SaveInformationAsync(MemoryCollectionName, id: "info2", text: "The last super hero movie watched by Gisela was Guardians of the Galaxy Vol 3");
-await memory.SaveInformationAsync(MemoryCollectionName, id: "info3", text: "Bruno's favourite super hero is Invincible");
-await memory.SaveInformationAsync(MemoryCollectionName, id: "info4", text: "The last super hero movie watched by Bruno was Aquaman II");
-await memory.SaveInformationAsync(MemoryCollectionName, id: "info5", text: "Bruno don't like the super hero movie: Eternals");
-
-TextMemoryPlugin memoryPlugin = new(memory);
-
-// Import the text memory plugin into the Kernel.
-kernel.ImportPluginFromObject(memoryPlugin);
-
-OpenAIPromptExecutionSettings settings = new()
-{
-    ToolCallBehavior = null,
-};
-
-
-var prompt = @"
-    Question: {{$input}}
-    Answer the question using the memory content: {{Recall}}";
-
-var arguments = new KernelArguments(settings)
-{
-    { "input", question },
-    { "collection", MemoryCollectionName }
-};
-
 Console.WriteLine($"Phi-3 response (using semantic memory).");
 
-response = kernel.InvokePromptStreamingAsync(prompt, arguments);
-await foreach (var result in response)
+var configOllamaKernelMemory = new OllamaConfig
 {
-    Console.Write(result);
-}
+    Endpoint = ollamaEndpoint,
+    TextModel = new OllamaModelConfig(modelIdChat),
+    EmbeddingModel = new OllamaModelConfig(modelIdEmbeddings, 2048)
+};
 
-Console.WriteLine($"");
+var memory = new KernelMemoryBuilder()
+    .WithOllamaTextGeneration(configOllamaKernelMemory)
+    .WithOllamaTextEmbeddingGeneration(configOllamaKernelMemory)
+    .Build();
+
+await memory.ImportTextAsync("Gisela's favourite super hero is Batman");
+await memory.ImportTextAsync("The last super hero movie watched by Gisela was Guardians of the Galaxy Vol 3");
+await memory.ImportTextAsync("Bruno's favourite super hero is Invincible");
+await memory.ImportTextAsync("The last super hero movie watched by Bruno was Deadpool and Wolverine");
+await memory.ImportTextAsync("Bruno don't like the super hero movie: Eternals");
+
+var answer = memory.AskStreamingAsync(question);
+await foreach (var result in answer)
+{
+    Console.Write(result.ToString());
+}

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Sample03.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Sample03.csproj
@@ -9,9 +9,15 @@
   </PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.19.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.19.0-alpha" />
+		<PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.KernelMemory.AI.Ollama" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.KernelMemory.Core" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.KernelMemory.SemanticKernelPlugin" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.34.0-alpha" />
 		<PackageReference Include="SmartComponents.LocalEmbeddings.SemanticKernel" Version="0.1.0-preview10148" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Sample03.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample03/Sample03.csproj
@@ -1,23 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>sample03</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.KernelMemory.AI.Ollama" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.KernelMemory.Core" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.KernelMemory.SemanticKernelPlugin" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
-		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.34.0-alpha" />
-		<PackageReference Include="SmartComponents.LocalEmbeddings.SemanticKernel" Version="0.1.0-preview10148" />
-		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
-	</ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.KernelMemory.AI.Ollama" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.KernelMemory.SemanticKernelPlugin" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.34.0-alpha" />
+    <PackageReference Include="SmartComponents.LocalEmbeddings.SemanticKernel" Version="0.1.0-preview10148" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+  </ItemGroup>
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample04/Sample04.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample04/Sample04.csproj
@@ -9,16 +9,16 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.5.24306.7" />
-
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0-preview.5.24306.7" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0-preview.5.24306.7" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0-preview.5.24306.7" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+		<PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.KernelMemory.AI.Ollama" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.KernelMemory.Core" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.KernelMemory.SemanticKernelPlugin" Version="0.96.250120.1" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.34.0-alpha" />
+		<PackageReference Include="SmartComponents.LocalEmbeddings.SemanticKernel" Version="0.1.0-preview10148" />
+		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.70" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample04/Sample04.csproj
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample04/Sample04.csproj
@@ -1,24 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>506e8050-acbd-476d-ab7d-bbebc8238bfa</UserSecretsId>
   </PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.KernelMemory.AI.Ollama" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.KernelMemory.Core" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.KernelMemory.SemanticKernelPlugin" Version="0.96.250120.1" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
-		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.34.0-alpha" />
-		<PackageReference Include="SmartComponents.LocalEmbeddings.SemanticKernel" Version="0.1.0-preview10148" />
-		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.70" />
-		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
-	</ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.KernelMemory.AI.Ollama" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.KernelMemory.SemanticKernelPlugin" Version="0.96.250120.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.34.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.34.0-alpha" />
+    <PackageReference Include="SmartComponents.LocalEmbeddings.SemanticKernel" Version="0.1.0-preview10148" />
+    <PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.70" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+  </ItemGroup>
 </Project>

--- a/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample04/SpectreConsoleOutput.cs
+++ b/md/07.Labs/CsharpOllamaCodeSpaces/src/Sample04/SpectreConsoleOutput.cs
@@ -1,0 +1,128 @@
+﻿//    Copyright (c) 2024
+//    Author      : Bruno Capuano
+//    Change Log  :
+//
+//    The MIT License (MIT)
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//    THE SOFTWARE.
+
+#pragma warning disable SKEXP0001, SKEXP0003, SKEXP0010, SKEXP0011, SKEXP0050, SKEXP0052
+using Spectre.Console;
+
+public static class SpectreConsoleOutput
+{
+    public static void DisplayTitle(string modelId = "")
+    {
+        var title = $"{modelId} RAG";
+
+        AnsiConsole.Write(new FigletText(title).Centered().Color(Color.Purple));
+    }
+
+    public static void DisplayTitleH2(string subtitle)
+    {
+        AnsiConsole.MarkupLine($"[bold][blue]=== {subtitle} ===[/][/]");
+        AnsiConsole.MarkupLine($"");
+    }
+
+    public static void DisplayTitleH3(string subtitle)
+    {
+        AnsiConsole.MarkupLine($"[bold]>> {subtitle}[/]");
+        AnsiConsole.MarkupLine($"");
+    }
+
+    public static void DisplaySeparator()
+    {
+        AnsiConsole.MarkupLine($"");
+        AnsiConsole.MarkupLine($"[bold][blue]==============[/][/]");
+        AnsiConsole.MarkupLine($"");
+    }
+
+    public static void WriteGreen(string message)
+    {
+        try
+        {
+            AnsiConsole.Markup($"[green]{message}[/]");
+        }
+        catch
+        {
+            AnsiConsole.Write($"{message}");
+        }
+    }
+
+    public static void DisplayQuestion(string question)
+    {
+        AnsiConsole.MarkupLine($"[bold][blue]>>Q: {question}[/][/]");
+        AnsiConsole.MarkupLine($"");
+    }
+    public static void DisplayAnswerStart(string answerPrefix)
+    {
+        AnsiConsole.Markup($"[bold][blue]>> {answerPrefix}:[/][/]");
+    }
+
+    public static void DisplayFilePath(string prefix, string filePath)
+    {
+        var path = new TextPath(filePath);
+
+        AnsiConsole.Markup($"[bold][blue]>> {prefix}: [/][/]");
+        AnsiConsole.Write(path);
+        AnsiConsole.MarkupLine($"");
+    }
+
+    public static void DisplaySubtitle(string prefix, string content)
+    {
+        AnsiConsole.Markup($"[bold][blue]>> {prefix}: [/][/]");
+        AnsiConsole.WriteLine(content);
+        AnsiConsole.MarkupLine($"");
+    }
+
+    public static int AskForNumber(string question)
+    {
+        var number = AnsiConsole.Ask<int>(@$"[green]{question}[/]");
+        return number;
+    }
+
+    public static string AskForString(string question)
+    {
+        var response = AnsiConsole.Ask<string>(@$"[green]{question}[/]");
+        return response;
+    }
+
+    public static List<string> SelectScenarios()
+    {
+        // Ask for the user's favorite fruits
+        var scenarios = AnsiConsole.Prompt(
+            new MultiSelectionPrompt<string>()
+                .Title("Select the [green]Phi 3 Vision scenarios[/] to run?")
+                .PageSize(10)
+                .Required(true)
+                .MoreChoicesText("[grey](Move up and down to reveal more scenarios)[/]")
+                .InstructionsText(
+                    "[grey](Press [blue]<space>[/] to toggle a scenario, " +
+                    "[green]<enter>[/] to accept)[/]")
+                .AddChoiceGroup("Select an image to be analuyzed", new[]
+                    {"foggyday.png","foggydaysmall.png","petsmusic.png","ultrarunningmug.png",
+                    })
+                .AddChoices( new[] { 
+                    "Type the image path to be analyzed",
+                    "Type a question"
+                    })
+                );
+        return scenarios;
+    }
+}


### PR DESCRIPTION
## Purpose

Update the CsharpOllamaCodeSpaces c# samples to use phi3.5 and fix the errors on the RAG samples


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: upgrade nuget packages
```


