### PR TITLE
Updated Lab1 and Lab4 to dispose objects when closing the app

### DIFF
--- a/md/07.Labs/Csharp/src/LabsPhi301/Program.cs
+++ b/md/07.Labs/Csharp/src/LabsPhi301/Program.cs
@@ -31,6 +31,7 @@ var modelPath = @"d:\phi3\models\Phi-3.5-mini-instruct-onnx\cpu_and_mobile\cpu-i
 
 var model = new Model(modelPath);
 var tokenizer = new Tokenizer(model);
+using OgaHandle ogaHandle = new();
 
 var systemPrompt = "You are an AI assistant that helps people find information. Answer questions using a direct style. Do not share more information that the requested by the users.";
 
@@ -44,7 +45,7 @@ while (true)
     // Get user question
     Console.WriteLine();
     Console.Write(@"Q: ");
-    var userQ = Console.ReadLine();    
+    var userQ = Console.ReadLine();
     if (string.IsNullOrEmpty(userQ))
     {
         break;
@@ -70,5 +71,13 @@ while (true)
         var output = tokenizer.Decode(newToken);
         Console.Write(output);
     }
+
+    // cleanup 
+    generator.Dispose();
+    generatorParams.Dispose();
+    tokenizer.Dispose();
+    model.Dispose();
+    ogaHandle.Dispose();
+
     Console.WriteLine();
 }


### PR DESCRIPTION
## Purpose

I've updated Lab1 and Lab4 to dispose of the resources before closing the application. I did not try the other labs. Without these changes, I was getting the following error:

"OGA Error: Shutdown must be called before process exit, please check the documentation for the proper API to call to ensure clean shutdown."

Also, I have seen issue in other posts.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


