### PR TITLE
Update Ollama documentation in Japanese

### DIFF
--- a/translations/ja/md/01.Introduction/02/04.Ollama.md
+++ b/translations/ja/md/01.Introduction/02/04.Ollama.md
@@ -78,6 +78,8 @@ curl http://127.0.0.1:11434/api/chat -d '{
   
 }'
 
+```
+
 This is the result in Postman
 
 ![Screenshot of JSON results for generate request](../../../../../translated_images/ollama_gen.bda5d4e715366cc9c1cae2956e30bfd55b07b22ca782ef69e680100a9a1fd563.ja.png)
@@ -174,7 +176,8 @@ Run the app with the command:
 
 ```bash
 dotnet run
-
+```
 
 **免責事項**：  
+
 本書類はAI翻訳サービス「[Co-op Translator](https://github.com/Azure/co-op-translator)」を使用して翻訳されました。正確性の向上に努めておりますが、自動翻訳には誤りや不正確な部分が含まれる可能性があります。原文の言語によるオリジナル文書が正式な情報源とみなされるべきです。重要な情報については、専門の人間による翻訳を推奨します。本翻訳の利用により生じたいかなる誤解や誤訳についても、当方は一切の責任を負いかねます。


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Removed metadata comments and updated the content of the Ollama documentation in Japanese, including installation instructions and API usage examples.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/01.Introduction/02/04.Ollama.md

related https://github.com/microsoft/PhiCookBook/pull/408

<img width="947" height="576" alt="image" src="https://github.com/user-attachments/assets/8001b8aa-42b7-427e-8b21-e16c68d81b2a" />

<img width="907" height="139" alt="image" src="https://github.com/user-attachments/assets/6dcc3b28-90ad-419a-87fc-7e615b1aeef0" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


