### PR TITLE
Update Ollama documentation in Japanese

### DIFF
--- a/translations/ja/md/01.Introduction/02/04.Ollama.md
+++ b/translations/ja/md/01.Introduction/02/04.Ollama.md
@@ -1,8 +1,8 @@
 <!--
 CO_OP_TRANSLATOR_METADATA:
 {
-  "original_hash": "0b38834693bb497f96bf53f0d941f9a1",
-  "translation_date": "2025-07-16T19:14:01+00:00",
+  "original_hash": "2aa35f3c8b437fd5dc9995d53909d495",
+  "translation_date": "2025-12-21T10:40:23+00:00",
   "source_file": "md/01.Introduction/02/04.Ollama.md",
   "language_code": "ja"
 }


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Removed metadata and updated the content of the Ollama documentation in Japanese.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/01.Introduction/02/04.Ollama.md

<img width="960" height="1731" alt="image" src="https://github.com/user-attachments/assets/bbe67dbf-205c-4d13-80e4-798d1d45259d" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


