### PR TITLE
Refactor Kaito Inference documentation

### DIFF
--- a/translations/ja/md/01.Introduction/03/Kaito_Inference.md
+++ b/translations/ja/md/01.Introduction/03/Kaito_Inference.md
@@ -32,7 +32,7 @@ Kaitoは、Kubernetesのカスタムリソース定義（CRD）とコントロ�
 
 - **Workspace controller**：`workspace`カスタムリソースを調整し、ノードの自動プロビジョニングをトリガーする`machine`（後述）カスタムリソースを作成し、モデルのプリセット構成に基づいて推論ワークロード（`deployment`または`statefulset`）を作成します。
 - **Node provisioner controller**：このコントローラーは[gpu-provisioner helm chart](https://github.com/Azure/gpu-provisioner/tree/main/charts/gpu-provisioner)内で*gpu-provisioner*と呼ばれています。`machine` CRDは[Karpenter](https://sigs.k8s.io/karpenter)由来で、workspace controllerと連携します。Azure Kubernetes Service（AKS）のAPIと統合し、AKSクラスターに新しいGPUノードを追加します。
-> Note: [*gpu-provisioner*](https://github.com/Azure/gpu-provisioner)はオープンソースのコンポーネントです。もし他のコントローラーが[Karpenter-core](https://sigs.k8s.io/karpenter) APIをサポートしていれば、置き換え可能です。
+> 注意: [*gpu-provisioner*](https://github.com/Azure/gpu-provisioner)はオープンソースのコンポーネントです。もし他のコントローラーが[Karpenter-core](https://sigs.k8s.io/karpenter) APIをサポートしていれば、置き換え可能です。
 
 ## インストール
 
@@ -176,4 +176,5 @@ $ kubectl run -it --rm --restart=Never curl --image=curlimages/curl -- curl -X P
 ```
 
 **免責事項**：  
+
 本書類はAI翻訳サービス「[Co-op Translator](https://github.com/Azure/co-op-translator)」を使用して翻訳されました。正確性の向上に努めておりますが、自動翻訳には誤りや不正確な部分が含まれる可能性があります。原文の言語によるオリジナル文書が正式な情報源とみなされるべきです。重要な情報については、専門の人間による翻訳を推奨します。本翻訳の利用により生じたいかなる誤解や誤訳についても、当方は責任を負いかねます。


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This commit removes metadata comments and updates the content of the Kaito Inference document, enhancing clarity and structure.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/01.Introduction/03/Kaito_Inference.md

<img width="975" height="251" alt="image" src="https://github.com/user-attachments/assets/994fc70a-d28b-4352-add6-6c70def98619" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


