### PR TITLE
Update iOS Inference documentation

### DIFF
--- a/translations/ja/md/01.Introduction/03/iOS_Inference.md
+++ b/translations/ja/md/01.Introduction/03/iOS_Inference.md
@@ -71,7 +71,7 @@ cd ../
 
 ## **3. iOS向けONNX Runtimeでの生成AIのコンパイル**
 
-> **Note:** ONNX Runtimeを使った生成AIはプレビュー段階のため、仕様変更の可能性があります。
+> **注意:** ONNX Runtimeを使った生成AIはプレビュー段階のため、仕様変更の可能性があります。
 
 ```bash
 
@@ -167,4 +167,5 @@ ONNX形式のINT4量子化モデルをインポートする必要があり、ま
 より多くのサンプルコードや詳細な手順は、[Phi-3 Mini Samplesリポジトリ](https://github.com/Azure-Samples/Phi-3MiniSamples/tree/main/ios)をご覧ください。
 
 **免責事項**：  
+
 本書類はAI翻訳サービス「[Co-op Translator](https://github.com/Azure/co-op-translator)」を使用して翻訳されました。正確性を期しておりますが、自動翻訳には誤りや不正確な部分が含まれる可能性があります。原文の言語によるオリジナル文書が正式な情報源とみなされます。重要な情報については、専門の人間による翻訳を推奨します。本翻訳の利用により生じた誤解や誤訳について、当方は一切の責任を負いかねます。


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Removed metadata comments and updated content for iOS inference guide.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/01.Introduction/03/iOS_Inference.md 

<img width="923" height="111" alt="image" src="https://github.com/user-attachments/assets/72a4a05c-6b92-40ea-bdab-e5640dff6078" />

#PingMSFTDocs


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


