### PR TITLE
Fix formatting and consistency in QuantifyingPhi.md

### DIFF
--- a/md/01.Introduction/04/QuantifyingPhi.md
+++ b/md/01.Introduction/04/QuantifyingPhi.md
@@ -26,7 +26,7 @@ On mobile devices or IoT devices, we can convert Phi-3.x models to INT4, while A
 
 At present, different hardware manufacturers have different frameworks to support generative models, such as Intel's OpenVINO, Qualcomm's QNN, Apple's MLX, and Nvidia's CUDA, etc., combined with model quantization to complete local deployment.
 
-In terms of technology, we have different format support after quantization, such as PyTorch / Tensorflow format, GGUF, and ONNX. I have done a format comparison and application scenarios between GGUF and ONNX. Here I recommend the ONNX quantization format, which has good support from the model framework to the hardware. In this chapter, we will focus on ONNX Runtime for GenAI, OpenVINO, and Apple MLX to perform model quantization (if you have a better way, you can also give it to us by submitting PR)
+In terms of technology, we have different format support after quantization, such as PyTorch / TensorFlow format, GGUF, and ONNX. I have done a format comparison and application scenarios between GGUF and ONNX. Here I recommend the ONNX quantization format, which has good support from the model framework to the hardware. In this chapter, we will focus on ONNX Runtime for GenAI, OpenVINO, and Apple MLX to perform model quantization (if you have a better way, you can also give it to us by submitting PR)
 
 **This chapter includes**
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
https://github.com/microsoft/PhiCookBook/blob/main/md/01.Introduction/04/QuantifyingPhi.md 

<img width="944" height="104" alt="image" src="https://github.com/user-attachments/assets/b5bd4e93-20dc-40f5-9aee-b6e030724956" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


