### PR TITLE
Fix formatting for advanced settings tip in documentation

### DIFF
--- a/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-FineTuning_PromptFlow_Integration_AIFoundry.md
+++ b/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-FineTuning_PromptFlow_Integration_AIFoundry.md
@@ -436,9 +436,9 @@ In this exercise, you will:
 
     ![Fill fine-tuning page.](../../../../imgs/02/FineTuning-PromptFlow-AIFoundry/06-07-fill-finetuning.png)
 
-    > [!TIP]
-    >
-    > You can select **Advanced settings** to customize configurations such as **learning_rate** and **lr_scheduler_type** to optimize the fine-tuning process according to your specific needs.
+> [!TIP]
+>
+> You can select **Advanced settings** to customize configurations such as **learning_rate** and **lr_scheduler_type** to optimize the fine-tuning process according to your specific needs.
 
 1. Select **Finish**.
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Updated tip formatting for advanced settings in fine-tuning instructions.

https://github.com/microsoft/PhiCookBook/blob/main/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-FineTuning_PromptFlow_Integration_AIFoundry.md 

<img width="898" height="182" alt="image" src="https://github.com/user-attachments/assets/ed6c72a1-246d-4609-b8cf-e19dfed82fbf" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


