### PR TITLE
Fix formatting for note section in documentation

### DIFF
--- a/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-mini_with_whisper.md
+++ b/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-mini_with_whisper.md
@@ -82,7 +82,7 @@ Installing Cuda GPU drivers
     - Enter project **Name** you want to use.
     - Select **Type** to **Write**.
 
-> **Note**
+> [!NOTE]
 >
 > If you encounter the following error:
 >


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
https://github.com/microsoft/PhiCookBook/blob/main/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-mini_with_whisper.md #PingMSFTDocs

<img width="951" height="260" alt="image" src="https://github.com/user-attachments/assets/1966075d-d05d-4427-a4b2-99454b3c7721" />


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


