### PR TITLE
Change image source for Phi-3.5 fine-tuning

### DIFF
--- a/translations/ja/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-FineTuning_PromptFlow_Integration.md
+++ b/translations/ja/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-FineTuning_PromptFlow_Integration.md
@@ -689,7 +689,7 @@ CO_OP_TRANSLATOR_METADATA:
 >
 > *fine_tune.py* ファイル内の `pretrained_model_name` を `"microsoft/Phi-3-mini-4k-instruct"` から任意のファインチューニングしたいモデル名に変更できます。例えば、`"microsoft/Phi-3.5-mini-instruct"` に変更すると Phi-3.5-mini-instruct モデルでファインチューニングします。希望するモデル名を見つけるには [Hugging Face](https://huggingface.co/) にアクセスし、興味のあるモデルを検索してその名前をスクリプト内の `pretrained_model_name` フィールドにコピー＆ペーストしてください。
 >
-> <image type="content" src="../../../../imgs/02/FineTuning-PromptFlow/finetunephi3.5.png" alt-text="Phi-3.5 をファインチューニング。">
+> <image type="content" src="../../../../../../translated_images/finetunephi3.5.a55fc02962430af5.ja.png" alt-text="Phi-3.5 をファインチューニング。">
 >
 
 #### *setup_ml.py* ファイルにコードを追加する


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Updated the image source for Phi-3.5 fine-tuning instructions.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-FineTuning_PromptFlow_Integration.md

<img width="939" height="226" alt="image" src="https://github.com/user-attachments/assets/1a63aff3-f4b0-42d0-b794-e1a036a85e25" />

<img width="936" height="492" alt="image" src="https://github.com/user-attachments/assets/913d75b9-8885-4cec-b936-20d693f45b4f" />


#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


