### PR TITLE
Update notes to use '注記' instead of 'Note'

### DIFF
--- a/translations/ja/md/02.Application/01.TextAndChat/Phi3/ORTWindowGPUGuideline.md
+++ b/translations/ja/md/02.Application/01.TextAndChat/Phi3/ORTWindowGPUGuideline.md
@@ -19,7 +19,7 @@ CO_OP_TRANSLATOR_METADATA:
 
 ### **1. Python 3.10.x /3.11.8**
 
-   ***Note*** Python環境には[Miniforge](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe)の使用を推奨します
+   ***注記*** Python環境には[Miniforge](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe)の使用を推奨します
 
    ```bash
 
@@ -41,7 +41,7 @@ CO_OP_TRANSLATOR_METADATA:
 
 ### **3. Visual Studio 2022 - C++によるデスクトップ開発をインストール**
 
-   ***Note*** コンパイルしない場合はこのステップをスキップできます
+   ***注記*** コンパイルしない場合はこのステップをスキップできます
 
 ![CPP](../../../../../../translated_images/01.42f52a2b2aedff02.ja.png)
 
@@ -87,7 +87,7 @@ NVIDIA CUDNN 9.4のlib、bin、includeフォルダの内容をNVIDIA CUDA 12.4�
 
 ### **8. ORT GenAI GPUのコンパイル**
 
-   ***Note*** 
+   ***注記*** 
    
    1. まず、onnx、onnxruntime、onnxruntime-genaiに関するすべてをアンインストールしてください
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/01.TextAndChat/Phi3/ORTWindowGPUGuideline.md 

<img width="997" height="429" alt="image" src="https://github.com/user-attachments/assets/0ffd3c0b-94bb-4f6d-ba18-21a786a321af" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


