### PR TITLE
Fix formatting and phrasing in Japanese documentation

### DIFF
--- a/translations/ja/md/02.Application/02.Code/Phi3/CreateVSCodeChatAgentWithGitHubModels.md
+++ b/translations/ja/md/02.Application/02.Code/Phi3/CreateVSCodeChatAgentWithGitHubModels.md
@@ -9,7 +9,7 @@ CO_OP_TRANSLATOR_METADATA:
 -->
 # **GitHub ModelsのPhi-3.5で自分だけのVisual Studio Code Chat Copilotエージェントを作成しよう**
 
-Visual Studio Code Copilotを使っていますか？特にChatでは、さまざまなエージェントを利用して、Visual Studio Codeでのプロジェクト作成、執筆、保守の能力を向上させることができます。Visual Studio Codeは、企業や個人が自社のビジネスに基づいて異なるエージェントを作成し、独自の分野での機能を拡張できるAPIを提供しています。この記事では、GitHub Modelsの**Phi-3.5-mini-instruct (128k)**と**Phi-3.5-vision-instruct (128k)**に焦点を当てて、自分だけのVisual Studio Codeエージェントを作成する方法を紹介します。
+Visual Studio Code Copilotを使っていますか？特にChatでは、さまざまなエージェントを利用して、Visual Studio Codeでのプロジェクト作成、執筆、保守の能力を向上させることができます。Visual Studio Codeは、企業や個人が自社のビジネスに基づいて異なるエージェントを作成し、独自の分野での機能を拡張できるAPIを提供しています。この記事では、GitHub Modelsの**Phi-3.5-mini-instruct (128k)** と**Phi-3.5-vision-instruct (128k)** に焦点を当てて、自分だけのVisual Studio Codeエージェントを作成する方法を紹介します。
 
 ## **GitHub ModelsのPhi-3.5について**
 
@@ -21,9 +21,9 @@ Phi-3/3.5ファミリーのPhi-3/3.5-mini-instructは、強力なコード理解
 
 ![gh](../../../../../../translated_images/gh.459640c7ceba01d5.ja.png)
 
-***Note: *** ここではAzure AI Inference SDKの使用を推奨します。なぜなら、本番環境でAzure Model Catalogとの切り替えがよりスムーズに行えるためです。
+***注記:*** ここではAzure AI Inference SDKの使用を推奨します。なぜなら、本番環境でAzure Model Catalogとの切り替えがよりスムーズに行えるためです。
 
-以下は、GitHub Modelsと連携した後のコード生成シナリオにおける**Phi-3.5-mini-instruct (128k)**と**Phi-3.5-vision-instruct (128k)**の結果で、以降の例の準備にもなっています。
+以下は、GitHub Modelsと連携した後のコード生成シナリオにおける**Phi-3.5-mini-instruct (128k)** と**Phi-3.5-vision-instruct (128k)** の結果で、以降の例の準備にもなっています。
 
 **デモ：GitHub Models Phi-3.5-mini-instruct (128k)によるプロンプトからのコード生成**（[こちらをクリック](../../../../../../code/09.UpdateSamples/Aug/ghmodel_phi35_instruct_demo.ipynb)）
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Corrected minor formatting and phrasing issues in the Japanese documentation for creating a Visual Studio Code Chat Copilot agent using GitHub Models Phi-3.5.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/02.Code/Phi3/CreateVSCodeChatAgentWithGitHubModels.md 

<img width="944" height="1755" alt="image" src="https://github.com/user-attachments/assets/bc5e035b-6316-410a-aa61-6c43211989ea" />

related https://github.com/Azure/co-op-translator/issues/240

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


