### PR TITLE
Change PHI3 image format to WebP

### DIFF
--- a/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/README.md
+++ b/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/README.md
@@ -75,7 +75,7 @@ GitHub Copilotは企業のプログラミング効率を大幅に向上させて
 
 このラボでは主にPhi-3モデルを使い、ローカルNPUとAzureのハイブリッドを組み合わせて、GitHub Copilot Chat内にカスタムエージェント ***@PHI3***を構築し、企業の開発者がコード生成 ***(@PHI3 /gen)*** や画像に基づくコード生成 ***(@PHI3 /img)*** を支援します。
 
-![PHI3](../../../../../../../translated_images/ja/cover.1017ebc9a7c46d09.png)
+![PHI3](../../../../../../../translated_images/ja/cover.1017ebc9a7c46d09.webp)
 
 ### ***Note:*** 
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Updated image format from PNG to WebP in README.md.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/README.md 

<img width="942" height="318" alt="image" src="https://github.com/user-attachments/assets/000b82fa-de0b-466f-9153-e1e9ed325cac" />
<img width="976" height="864" alt="image" src="https://github.com/user-attachments/assets/aa3119bd-949b-4ff8-9f49-bf8e3a6dd55f" />


#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


