### PR TITLE
Update notes to Japanese annotations in documentation

### DIFF
--- a/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/HOL/Apple/02.PromptflowWithMLX.md
+++ b/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/HOL/Apple/02.PromptflowWithMLX.md
@@ -31,7 +31,7 @@ Prompt flowを使うと、以下が可能になります：
 
 ## **Apple Silicon上での生成コードフロー構築**
 
-***Note*** ：環境構築がまだの場合は、[Lab 0 -Installations](./01.Installations.md)をご参照ください。
+***注記*** ：環境構築がまだの場合は、[Lab 0 -Installations](./01.Installations.md)をご参照ください。
 
 1. Visual Studio CodeのPrompt flow拡張機能を開き、空のフロープロジェクトを作成します。
 
@@ -75,7 +75,7 @@ python -m mlx_lm.convert --hf-path microsoft/Phi-3-mini-4k-instruct
 
 ```
 
-**Note:** デフォルトのフォルダはmlx_modelです。
+**注記:** デフォルトのフォルダはmlx_modelです。
 
 4. ***Chat_With_Phi3.py***にコードを追加します。
 
@@ -121,7 +121,7 @@ pf flow serve --source ./ --port 8080 --host localhost
 PostmanやThunder Clientでテスト可能です。
 
 
-### **Note**
+### **注記**
 
 1. 初回実行は時間がかかります。Hugging face CLIからphi-3モデルをダウンロードすることを推奨します。
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/HOL/Apple/02.PromptflowWithMLX.md 

<img width="947" height="928" alt="image" src="https://github.com/user-attachments/assets/6fe3d874-8782-49d9-ad15-fa4404fcaf44" />

#PingMSFTDocs


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


