### PR TITLE
Update translation for note section in Azure deployment guide

### DIFF
--- a/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/HOL/Apple/03.DeployPhi3VisionOnAzure.md
+++ b/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/HOL/Apple/03.DeployPhi3VisionOnAzure.md
@@ -13,7 +13,7 @@ CO_OP_TRANSLATOR_METADATA:
 
 この紹介では、Azure Machine Learning Service上でModel As ServiceとしてPhi-3 Visionサービスを素早く構築する方法を説明します。
 
-***Note***：Phi-3 Visionは高速にコンテンツを生成するために計算リソースが必要です。これを実現するためにクラウドの計算力を活用します。
+***注記***：Phi-3 Visionは高速にコンテンツを生成するために計算リソースが必要です。これを実現するためにクラウドの計算力を活用します。
 
 
 ### **1. Azure Machine Learning Serviceの作成**
@@ -38,7 +38,7 @@ AzureポータルでAzure Machine Learning Serviceを作成する必要があり
 ![Test](../../../../../../../../../translated_images/ja/vision_test.0b9c1b1d414131d0.webp)
 
 
-***Note***
+***注記***
 
 1. 送信するパラメーターにはAuthorization、azureml-model-deployment、Content-Typeが含まれている必要があります。これらはデプロイ情報から確認してください。
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Replace 'Note' with '注記' for consistency in Japanese translation.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/02.Code/Phi3/VSCodeExt/HOL/Apple/03.DeployPhi3VisionOnAzure.md

<img width="1016" height="271" alt="image" src="https://github.com/user-attachments/assets/be55ee75-828f-4a20-96a7-cd9c3ab762aa" />


#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


