### PR TITLE
Fix formatting of note about GitHub token permissions

### DIFF
--- a/md/02.Application/02.Code/Phi4r/azure_models_inference.ipynb
+++ b/md/02.Application/02.Code/Phi4r/azure_models_inference.ipynb
@@ -89,7 +89,7 @@
     "3. Replace `your_personal_access_token_here` with your GitHub Personal Access Token\n",
     "4. You can optionally change the model to `microsoft/Phi-4-mini-reasoning` for a smaller model\n",
     "\n",
-    "**Note:** The GitHub token requires appropriate permissions to access the AI models service. \n",
+    "**Note:** The GitHub token requires appropriate permissions to access the AI models service. \n\n",
     "**Note:** Keep your Azure API key secure and don't share it in public repositories or notebooks."
    ]
   },


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
https://github.com/microsoft/PhiCookBook/blob/main/md/02.Application/02.Code/Phi4r/azure_models_inference.ipynb 

<img width="832" height="106" alt="image" src="https://github.com/user-attachments/assets/89793e39-5010-4ad3-9003-771748a1aee8" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


