### PR TITLE
Revise note terminology in MLX_Inference.md

### DIFF
--- a/translations/ja/md/03.FineTuning/03.Inference/MLX_Inference.md
+++ b/translations/ja/md/03.FineTuning/03.Inference/MLX_Inference.md
@@ -53,7 +53,7 @@ python -m mlx_lm.convert --hf-path microsoft/Phi-3-mini-4k-instruct
 
 ```
 
-***Note：*** モデルはmlx_lm.convertを使って量子化でき、デフォルトの量子化はINT4です。この例ではPhi-3-miniをINT4に量子化しています。
+***注記：*** モデルはmlx_lm.convertを使って量子化でき、デフォルトの量子化はINT4です。この例ではPhi-3-miniをINT4に量子化しています。
 
 モデルはmlx_lm.convertで量子化可能で、デフォルトはINT4です。この例ではPhi-3-miniをINT4に量子化し、量子化後のモデルはデフォルトのディレクトリ ./mlx_model に保存されます。
 
@@ -76,7 +76,7 @@ python -m mlx_lm.generate --model ./mlx_model/ --max-token 2048 --prompt  "<|use
 
 ![Notebook](../../../../../translated_images/ja/03.b9705a3a5aaa89f9.webp)
 
-***Note:*** このサンプルは[こちらのリンク](../../../../../code/03.Inference/MLX/MLX_DEMO.ipynb)からご覧ください。
+***注記:*** このサンプルは[こちらのリンク](../../../../../code/03.Inference/MLX/MLX_DEMO.ipynb)からご覧ください。
 
 
 ## **リソース**


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Updated notes from 'Note' to '注記' for consistency in Japanese translation.

https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/03.FineTuning/03.Inference/MLX_Inference.md 

<img width="991" height="1332" alt="image" src="https://github.com/user-attachments/assets/ff320327-681e-4c5b-b9f1-246fbfffd31e" />

#PingMSFTDocs


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


