### PR TITLE
[docs] Create data directory in MLX Phi-4 reasoning notebook

### DIFF
--- a/md/02.Application/03.AdvancedReasoning/Phi4/AdvancedResoningPhi4mini/mlx_ft_phi_4_reasoning_with_medicaldata.ipynb
+++ b/md/02.Application/03.AdvancedReasoning/Phi4/AdvancedResoningPhi4mini/mlx_ft_phi_4_reasoning_with_medicaldata.ipynb
@@ -99,6 +99,7 @@
     }
    ],
    "source": [
+    "from pathlib import Path\n",
     "from datasets import load_dataset"
    ]
   },
@@ -201,6 +202,7 @@
     }
    ],
    "source": [
+    "Path(\"./data\").mkdir(exist_ok=True)\n",
     "train_dataset = train_dataset.map(formatting_prompts_func, batched = True,remove_columns=[\"Question\", \"Complex_CoT\", \"Response\"])\n",
     "train_dataset.to_json(\"./data/train.jsonl\")"
    ]


### PR DESCRIPTION
## Summary

Creates the `./data` directory before the MLX Phi-4 reasoning fine-tuning notebook writes generated JSONL files.

The notebook currently writes to `./data/train.jsonl` and `./data/valid.jsonl`, but the `data` directory is not present in a fresh checkout and is not created before those writes.

## Changes

- Add `Path("data").mkdir(exist_ok=True)` before exporting JSONL files
- Keep the existing `train.jsonl` and `valid.jsonl` output filenames
- Limit the change to the MLX Phi-4 reasoning notebook

## Validation

- Confirmed `md/02.Application/03.AdvancedReasoning/Phi4/AdvancedResoningPhi4mini/data` is absent in a fresh checkout
- Confirmed the notebook writes to `./data/train.jsonl` and `./data/valid.jsonl`
- Confirmed the updated notebook creates `./data` before those writes