### PR TITLE
docs: fix missing media inputs in TechJournalist notebook

### DIFF
--- a/md/02.Application/08.Multimodel/Phi4/TechJournalist/phi_4_mm_audio_text_publish_news.ipynb
+++ b/md/02.Application/08.Multimodel/Phi4/TechJournalist/phi_4_mm_audio_text_publish_news.ipynb
@@ -392,7 +392,8 @@
       },
       "outputs": [],
       "source": [
-        "image = Image.open(image_path)"
+        "with Image.open(image_path) as img:\n",
+        "    image = img.copy()"
       ]
     },
     {

--- a/md/02.Application/08.Multimodel/Phi4/TechJournalist/phi_4_mm_audio_text_publish_news.ipynb
+++ b/md/02.Application/08.Multimodel/Phi4/TechJournalist/phi_4_mm_audio_text_publish_news.ipynb
@@ -224,7 +224,9 @@
       "outputs": [],
       "source": [
         "import requests\n",
+        "import urllib.request\n",
         "import torch\n",
+        "from pathlib import Path\n",
         "from PIL import Image\n",
         "import soundfile\n",
         "from transformers import AutoModelForCausalLM, AutoProcessor, GenerationConfig,pipeline,AutoTokenizer"
@@ -363,12 +365,34 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "media_dir = Path(\"media\")\n",
+        "media_dir.mkdir(exist_ok=True)\n",
+        "\n",
+        "image_path = media_dir / \"copilot.png\"\n",
+        "audio_path = media_dir / \"sample_audio.mp3\"\n",
+        "\n",
+        "sample_media = {\n",
+        "    image_path: \"https://raw.githubusercontent.com/microsoft/PhiCookBook/main/imgs/02/pfonnx/pfv.png\",\n",
+        "    audio_path: \"https://raw.githubusercontent.com/Azure-Samples/cognitive-services-speech-sdk/master/samples/csharp/sharedcontent/console/whatstheweatherlike.mp3\",\n",
+        "}\n",
+        "\n",
+        "for path, url in sample_media.items():\n",
+        "    if not path.exists():\n",
+        "        urllib.request.urlretrieve(url, path)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "npQ3zBSPiWPS"
       },
       "outputs": [],
       "source": [
-        "image = Image.open(\"./copilot.png\")"
+        "image = Image.open(image_path)"
       ]
     },
     {
@@ -379,7 +403,7 @@
       },
       "outputs": [],
       "source": [
-        "audio = soundfile.read('./satya1.mp3')"
+        "audio = soundfile.read(audio_path)"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Fixes #536.

This updates the Phi-4 multimodal TechJournalist notebook so the image and audio inputs no longer rely on missing local files.

## Changes

- Adds a lightweight setup cell that creates a local `media/` directory.
- Downloads sample image/audio media only when missing.
- Replaces the previous hard-coded missing paths with explicit `image_path` and `audio_path` variables.
- Keeps the existing notebook flow unchanged.
- Does not add binary files to the repo.

## Validation

- Parsed the updated notebook JSON successfully.
- Verified the old `./copilot.png` and `./satya1.mp3` references are no longer used by the loading cells.
- Verified the new `image_path`, `audio_path`, `media_dir`, and `urllib.request` setup references exist.
- Ran a temp-directory smoke test for download, `Image.open(...)`, and `soundfile.read(...)`.

Note: local validation initially required installing `soundfile`, then the smoke test passed after explicitly closing the image handle before temp cleanup.